### PR TITLE
Allow setting of global attributes

### DIFF
--- a/src/Purifier.php
+++ b/src/Purifier.php
@@ -133,7 +133,14 @@ class Purifier
             $validValues = $attribute[2];
 
             if ($onElement === '*') {
-                $definition->info_global_attr[$attrName] = $validValues;
+                $def = $validValues;
+                if (is_string($validValues)) {
+                    $def = new $validValues();
+                }
+
+                if ($def instanceof \HTMLPurifier_AttrDef) {
+                    $definition->info_global_attr[$attrName] = $def;
+                }
 
                 continue;
             }

--- a/src/Purifier.php
+++ b/src/Purifier.php
@@ -132,6 +132,12 @@ class Purifier
             $attrName = $required ? $attribute[1] . '*' : $attribute[1];
             $validValues = $attribute[2];
 
+            if ($onElement === '*') {
+                $definition->info_global_attr[$attrName] = $validValues;
+
+                continue;
+            }
+
             $definition->addAttribute($onElement, $attrName, $validValues);
         }
 


### PR DESCRIPTION
The underlying [htmlpurifier](https://github.com/ezyang/htmlpurifier) library requires that the third index for the global attribute be an object that extends [HTMLPurifier_AttrDef](https://github.com/ezyang/htmlpurifier/blob/master/library/HTMLPurifier/AttrDef.php).

Usage as attributes for a custom definition:

```php
<?php
// config/purifier.php
return [
	// ...
	'settings' => [
		// ...
		'custom_definition' => [
			// ...
			'attributes' => [
				// ...
				['*', 'itemscope', new HTMLPurifier_AttrDef_HTML_Bool()],
				['*', 'itemtype', new HTMLPurifier_AttrDef_URI()],
				['*', 'itemprop', new HTMLPurifier_AttrDef_Text()],
			],
		],
	],
];
```

Usage as custom attributes:

```php
<?php
// config/purifier.php
return [
	// ...
	'settings' => [
		// ...
		'custom_attributes' => [
			// ...
			['*', 'itemscope', new HTMLPurifier_AttrDef_HTML_Bool()],
			['*', 'itemtype', new HTMLPurifier_AttrDef_URI()],
			['*', 'itemprop', new HTMLPurifier_AttrDef_Text()],
		],
	],
];
```